### PR TITLE
修复了当答案和猜测单词均有两个相同字母，且答案第一个相同字母猜测正确时，另外一个字母可能颜色错误的问题

### DIFF
--- a/nonebot_plugin_wordle/data_source.py
+++ b/nonebot_plugin_wordle/data_source.py
@@ -74,17 +74,19 @@ class Wordle(object):
         board = Image.new("RGB", board_size, self.bg_color)
 
         for i in range(self.rows):
-            word_temp = self.word_lower  # 临时变量
+            word_temp = ""  # 临时变量
+            for j in range(self.length):
+                if len(self.guessed_words) > i and self.guessed_words[i][j] != self.word_lower[j]:
+                    word_temp += self.word_lower[j]
+                else:
+                    word_temp += "_"
             for j in range(self.length):
                 letter = self.guessed_words[i][j] if len(self.guessed_words) > i else ""
                 if letter:
                     if letter == self.word_lower[j]:
                         color = self.correct_color
 
-                    elif (
-                        letter in word_temp
-                        and self.guessed_words[i][word_temp.find(letter)] != letter
-                    ):
+                    elif letter in word_temp:
                         """
                         一个字母的黄色和绿色数量与答案中的数量保持一致
                         以输入apple，答案adapt为例


### PR DESCRIPTION
Fixed a bug where the color may be incorrect when there are two identical letters in the answer word.
当答案单词有两个相同字母，如chara，猜测单词也有一致的两个相同字母，如adapt，此时adapt第一个字母应当为黄色，第三个字母应当为绿色。而原代码只是简单的查找chara中第一个a位置（本例中为2），然后查看该位置是否和猜测相同（本例中为相同，即chara的第一个a和adapt的第二个a相同），此时触发了原代码中的!=部分，导致这个位置错误的被判定为了灰色。
pr的代码解决了这一问题。