### PR TITLE
增加了统计数据

### DIFF
--- a/nonebot_plugin_wordle/__init__.py
+++ b/nonebot_plugin_wordle/__init__.py
@@ -1,4 +1,5 @@
 import json
+import os
 import asyncio
 import re
 import shlex
@@ -132,12 +133,18 @@ def shortcut(cmd: str, argv: List[str] = [], **kwargs):
             args = []
         await handle_wordle(bot, matcher, event, argv + args)
 
+directory = "data/wordle/"
+filepath = os.path.join(directory, "wordle_data.json")
 
 def update_json_file(self, user_id: str, vague_count: int, precise_count: int, is_correct: int):
+    global filepath
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
     try:
-        with open("wordle_data.json", "r") as f:
+        with open(filepath, "r") as f:
             data = json.load(f)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, FileNotFoundError):
         data = {}
 
     user_data = data.get(str(user_id), {})
@@ -152,7 +159,7 @@ def update_json_file(self, user_id: str, vague_count: int, precise_count: int, i
     user_data[str(self.length)] = length_data
     data[str(user_id)] = user_data
     
-    with open("wordle_data.json", "w") as f:
+    with open(filepath, "w") as f:
         json.dump(data, f, indent=4)
 
 # 命令前缀为空则需要to_me，否则不需要

--- a/nonebot_plugin_wordle/__init__.py
+++ b/nonebot_plugin_wordle/__init__.py
@@ -1,5 +1,3 @@
-import json
-import os
 import asyncio
 import re
 import shlex
@@ -39,7 +37,7 @@ supported_adapters = (
 )
 
 from .data_source import GuessResult, Wordle
-from .utils import dic_list, random_word
+from .utils import dic_list, random_word, update_json_file
 
 __plugin_meta__ = PluginMetadata(
     name="猜单词",
@@ -133,34 +131,6 @@ def shortcut(cmd: str, argv: List[str] = [], **kwargs):
             args = []
         await handle_wordle(bot, matcher, event, argv + args)
 
-directory = "data/wordle/"
-filepath = os.path.join(directory, "wordle_data.json")
-
-def update_json_file(self, user_id: str, vague_count: int, precise_count: int, is_correct: int):
-    global filepath
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-    try:
-        with open(filepath, "r") as f:
-            data = json.load(f)
-    except (json.JSONDecodeError, FileNotFoundError):
-        data = {}
-
-    user_data = data.get(str(user_id), {})
-    length_data = user_data.get(str(self.length), {})
-    
-    length_data['vague_letter_count'] = length_data.get('vague_letter_count', 0) + vague_count
-    length_data['precise_letter_count'] = length_data.get('precise_letter_count', 0) + precise_count
-    length_data['guessed_times'] = length_data.get('guessed_times', 0) + 1
-    length_data['is_correct'] = length_data.get('is_correct', 0) + is_correct
-
-    # 更新数据结构
-    user_data[str(self.length)] = length_data
-    data[str(user_id)] = user_data
-    
-    with open(filepath, "w") as f:
-        json.dump(data, f, indent=4)
 
 # 命令前缀为空则需要to_me，否则不需要
 def smart_to_me(command_start: str = CommandStart(), to_me: bool = EventToMe()) -> bool:

--- a/nonebot_plugin_wordle/data_source.py
+++ b/nonebot_plugin_wordle/data_source.py
@@ -1,5 +1,3 @@
-import json
-
 from enum import Enum
 from io import BytesIO
 from typing import List, Optional, Tuple

--- a/nonebot_plugin_wordle/utils.py
+++ b/nonebot_plugin_wordle/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 from io import BytesIO
 from pathlib import Path
@@ -40,3 +41,32 @@ def save_png(frame: IMG) -> BytesIO:
 
 def load_font(name: str, fontsize: int) -> FreeTypeFont:
     return ImageFont.truetype(str(fonts_dir / name), fontsize, encoding="utf-8")
+
+directory = "data/wordle/"
+filepath = os.path.join(directory, "wordle_data.json")
+
+def update_json_file(self, user_id: str, vague_count: int, precise_count: int, is_correct: int):
+    global filepath
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    try:
+        with open(filepath, "r") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError):
+        data = {}
+
+    user_data = data.get(str(user_id), {})
+    length_data = user_data.get(str(self.length), {})
+    
+    length_data['vague_letter_count'] = length_data.get('vague_letter_count', 0) + vague_count
+    length_data['precise_letter_count'] = length_data.get('precise_letter_count', 0) + precise_count
+    length_data['guessed_times'] = length_data.get('guessed_times', 0) + 1
+    length_data['is_correct'] = length_data.get('is_correct', 0) + is_correct
+
+    # 更新数据结构
+    user_data[str(self.length)] = length_data
+    data[str(user_id)] = user_data
+    
+    with open(filepath, "w") as f:
+        json.dump(data, f, indent=4)


### PR DESCRIPTION
增加了wordle游戏的统计数据，保存在。但是现在问题是我想通过QQ合并转发消息来发送统计消息，但可能由于import的原因无法正常调用合并转发API，下面是我尝试加入合并转发但是报错的版本：
https://github.com/Sevenyine/nonebot-plugin-wordle/commit/474bd92daa4d9661341d056cb3aa6eb8a3825059
可能还得麻烦大佬帮忙修修了（）如果直接发出来实在是刷屏但是用了合并转发其他平台的支持就少了
报错是ActionFailed，测试版和上面的commit一样实在不会修了
```
09-16 23:17:30 [ERROR] nonebot | Running Matcher(type='message', module=nonebot_plugin_wordle, lineno=95) failed.
Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/__init__.py", line 331, in run
    get_driver().run(*args, **kwargs)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/drivers/fastapi.py", line 201, in run
    uvicorn.run(
  File "/opt/homebrew/lib/python3.11/site-packages/uvicorn/main.py", line 587, in run
    server.run()
  File "/opt/homebrew/lib/python3.11/site-packages/uvicorn/server.py", line 61, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/message.py", line 467, in check_and_run_matcher
    await _run_matcher(
> File "/opt/homebrew/lib/python3.11/site-packages/nonebot/message.py", line 419, in _run_matcher
    await matcher.run(bot, event, state, stack, dependency_cache)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/internal/matcher/matcher.py", line 846, in run
    await self.simple_run(bot, event, state, stack, dependency_cache)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/internal/matcher/matcher.py", line 821, in simple_run
    await handler(
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/dependencies/__init__.py", line 113, in __call__
    return await cast(Callable[..., Awaitable[R]], self.call)(**values)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot_plugin_wordle/__init__.py", line 107, in _
    await handle_wordle(bot, qbot, qevent, matcher, event, argv)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot_plugin_wordle/__init__.py", line 273, in handle_wordle
    await qbot.send_group_forward_msg(
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/internal/adapter/bot.py", line 120, in call_api
    raise exception
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/internal/adapter/bot.py", line 98, in call_api
    result = await self.adapter._call_api(self, api, **data)
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/adapters/onebot/v11/adapter.py", line 143, in _call_api
    return handle_api_result(await self._result_store.fetch(seq, timeout))
  File "/opt/homebrew/lib/python3.11/site-packages/nonebot/adapters/onebot/v11/utils.py", line 58, in handle_api_result
    raise ActionFailed(**result)
nonebot.adapters.onebot.v11.exception.ActionFailed: ActionFailed(status='failed', retcode=1404, data={'message': '不支持的动作请求'}, echo='1')
```