### PR TITLE
小修改正则表达式使之可匹配消息文字后的空格

### DIFF
--- a/nonebot_plugin_wordle/__init__.py
+++ b/nonebot_plugin_wordle/__init__.py
@@ -168,7 +168,7 @@ async def _(
     games[user_id] = game
     set_timeout(matcher, user_id)
     matcher_word = on_regex(
-        rf"^(?P<word>[a-zA-Z]{{{length.result}}})$",
+        rf"^(?P<word>[a-zA-Z]{{{length.result}}})\s*$",
         rule=same_user(user_id),
         block=True,
         priority=14,


### PR DESCRIPTION
有些人的输入法会在打完英文单词之后会自动添加空格导致无法匹配，这个更改使之能匹配空格，优化使用体验